### PR TITLE
Fixed container overflow bug and implemented a 40 character limit

### DIFF
--- a/source/client/assets/scripts/AudioObjectList/AudioCard.js
+++ b/source/client/assets/scripts/AudioObjectList/AudioCard.js
@@ -35,12 +35,17 @@ class AudioCard extends HTMLElement {
         align-items: center;
         text-align: center;
         min-width: 150px;
-        height: 200px;
+        min-height: 200px;
         background: linear-gradient(180deg, #FFECD2 0%, #FCB69F 100%);;
         border-style: solid;
         border-width: 2px;
         box-shadow: 2px 2px 2px; 
         margin: 35px 20px 20px 20px;
+        max-width: 150px;
+        max-height: 300px;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+        word-break: break-word;
     }
     
     .musicIcon{

--- a/source/client/assets/scripts/AudioObjectList/CreateAudioFlow.js
+++ b/source/client/assets/scripts/AudioObjectList/CreateAudioFlow.js
@@ -62,7 +62,7 @@ class CreateAudioFlow extends HTMLElement {
     filesubmit.addEventListener("click", evt => {
       evt.preventDefault();
 
-      if(textinput.value.length > 40){
+      if (textinput.value.length > 40){
         console.log("test");
         window.alert("Invalid name. Please use 40 or less characters");
       }

--- a/source/client/assets/scripts/AudioObjectList/CreateAudioFlow.js
+++ b/source/client/assets/scripts/AudioObjectList/CreateAudioFlow.js
@@ -63,7 +63,6 @@ class CreateAudioFlow extends HTMLElement {
       evt.preventDefault();
 
       if (textinput.value.length > 40){
-        console.log("test");
         window.alert("Invalid name. Please use 40 or less characters");
       }
 

--- a/source/client/assets/scripts/AudioObjectList/CreateAudioFlow.js
+++ b/source/client/assets/scripts/AudioObjectList/CreateAudioFlow.js
@@ -62,14 +62,21 @@ class CreateAudioFlow extends HTMLElement {
     filesubmit.addEventListener("click", evt => {
       evt.preventDefault();
 
-      const submitEvent = new CustomEvent("fileSubmitted", {
-        detail: {
-          name: textinput.value,
-          path: fileinput.files[0].path
-        }
-      });
+      if(textinput.value.length > 40){
+        console.log("test");
+        window.alert("Invalid name. Please use 40 or less characters");
+      }
 
-      this.dispatchEvent(submitEvent);
+      else{
+        const submitEvent = new CustomEvent("fileSubmitted", {
+          detail: {
+            name: textinput.value,
+            path: fileinput.files[0].path
+          }
+        });
+
+        this.dispatchEvent(submitEvent);
+      }
     });
 
     //appending all the elements to its respective parents

--- a/source/client/assets/scripts/FolderAList/FolderACard.js
+++ b/source/client/assets/scripts/FolderAList/FolderACard.js
@@ -36,12 +36,17 @@
           align-items: center;
           text-align: center;
           min-width: 150px;
-          height: 200px;
+          min-height: 200px;
           background: linear-gradient(180deg, #FFECD2 0%, #FCB69F 100%);;
           border-style: solid;
           border-width: 2px;
           box-shadow: 2px 2px 2px; 
           margin: 35px 20px 20px 20px;
+          max-width: 150px;
+          max-height: 300px;
+          word-wrap: break-word;
+          white-space: pre-wrap;
+          word-break: break-word;
       }
       
       .musicIcon{

--- a/source/client/assets/scripts/FolderAList/FolderACreate.js
+++ b/source/client/assets/scripts/FolderAList/FolderACreate.js
@@ -56,7 +56,7 @@
       filesubmit.addEventListener("click", evt => {
         evt.preventDefault();
   
-        if(textinput.value.length > 40){
+        if (textinput.value.length > 40){
           console.log("test");
           window.alert("Invalid name. Please use 40 or less characters");
         }

--- a/source/client/assets/scripts/FolderAList/FolderACreate.js
+++ b/source/client/assets/scripts/FolderAList/FolderACreate.js
@@ -57,7 +57,6 @@
         evt.preventDefault();
   
         if (textinput.value.length > 40){
-          console.log("test");
           window.alert("Invalid name. Please use 40 or less characters");
         }
 

--- a/source/client/assets/scripts/FolderAList/FolderACreate.js
+++ b/source/client/assets/scripts/FolderAList/FolderACreate.js
@@ -56,14 +56,20 @@
       filesubmit.addEventListener("click", evt => {
         evt.preventDefault();
   
-        const submitEvent = new CustomEvent("fileSubmitted", {
-          detail: {
-            name: textinput.value,
-            parent: sessionStorage.getItem("FolderF")
-          }
-        });
-  
-        this.dispatchEvent(submitEvent);
+        if(textinput.value.length > 40){
+          console.log("test");
+          window.alert("Invalid name. Please use 40 or less characters");
+        }
+
+        else{
+          const submitEvent = new CustomEvent("fileSubmitted", {
+            detail: {
+              name: textinput.value,
+              parent: sessionStorage.getItem("FolderF")
+            }
+          });
+          this.dispatchEvent(submitEvent);
+        }
       });
   
       // append all the elements to its respective parents

--- a/source/client/assets/scripts/FolderFList/FolderFCard.js
+++ b/source/client/assets/scripts/FolderFList/FolderFCard.js
@@ -36,14 +36,19 @@ class FolderFCard extends HTMLElement {
       align-items: center;
       text-align: center;
       min-width: 150px;
-      height: 200px;
+      min-height: 200px;
       background: linear-gradient(180deg, #FFECD2 0%, #FCB69F 100%);;
       border-style: solid;
       border-width: 2px;
       box-shadow: 2px 2px 2px; 
       margin: 35px 20px 20px 20px;
+      max-width: 150px;
+      max-height: 300px;
+      word-wrap: break-word;
+      white-space: pre-wrap;
+      word-break: break-word;
     }
-      
+
     .musicIcon{
       width: 50px;
       height: 50px;

--- a/source/client/assets/scripts/FolderFList/FolderFCreate.js
+++ b/source/client/assets/scripts/FolderFList/FolderFCreate.js
@@ -57,10 +57,11 @@ class FolderFCreate extends HTMLElement {
     filesubmit.addEventListener("click", evt => {
       evt.preventDefault();
   
-      if(textinput.value.length > 40){
+      if (textinput.value.length > 40){
         console.log("test");
         window.alert("Invalid name. Please use 40 or less characters");
       }
+      
       else{
         const submitEvent = new CustomEvent("fileSubmitted", {
           detail: {

--- a/source/client/assets/scripts/FolderFList/FolderFCreate.js
+++ b/source/client/assets/scripts/FolderFList/FolderFCreate.js
@@ -58,7 +58,6 @@ class FolderFCreate extends HTMLElement {
       evt.preventDefault();
   
       if (textinput.value.length > 40){
-        console.log("test");
         window.alert("Invalid name. Please use 40 or less characters");
       }
       

--- a/source/client/assets/scripts/FolderFList/FolderFCreate.js
+++ b/source/client/assets/scripts/FolderFList/FolderFCreate.js
@@ -57,13 +57,19 @@ class FolderFCreate extends HTMLElement {
     filesubmit.addEventListener("click", evt => {
       evt.preventDefault();
   
-      const submitEvent = new CustomEvent("fileSubmitted", {
-        detail: {
-          name: textinput.value,
-        }
-      });
-  
-      this.dispatchEvent(submitEvent);
+      if(textinput.value.length > 40){
+        console.log("test");
+        window.alert("Invalid name. Please use 40 or less characters");
+      }
+      else{
+        const submitEvent = new CustomEvent("fileSubmitted", {
+          detail: {
+            name: textinput.value,
+          }
+        });
+    
+        this.dispatchEvent(submitEvent);
+      }
     });
   
     // appending all the elements created


### PR DESCRIPTION
A bug persisted where longer amounts of text would overflow in the cards that hold these text.

The text now wraps and is contained within the card. In addition there is now a 40 character limit when creating a card. If the user attempts to add more than 40 characters they will be notified and asked to choose a different name.

*Note: The 40 character limit can easily be changed if it is too little*