### PR TITLE
Implemented error handling when creating folders/files

### DIFF
--- a/source/client/assets/scripts/AudioObjectList/FileUpload.js
+++ b/source/client/assets/scripts/AudioObjectList/FileUpload.js
@@ -45,21 +45,27 @@ addButton.addEventListener("click", () => {
 
   // When the user submits a new audio file
   createAudObject.addEventListener("fileSubmitted", evt => {
-    // Remove the input prompt
-    document.body.removeChild(createAudObject);
+    try{
+      // Create a new audio card
+      audio_utils.add_audio(folderFName, folderAName, evt.detail.name, evt.detail.path);
+      createAudioCard(evt.detail.name);
 
-    // Create a new audio card
-    createAudioCard(evt.detail.name);
-    audio_utils.add_audio(folderFName, folderAName, evt.detail.name, evt.detail.path);
+      // Remove the input prompt
+      document.body.removeChild(createAudObject);
 
-    // Show success screen
-    const successScreen = document.createElement("success-screen");
-    document.body.appendChild(successScreen);
+      // Show success screen
+      const successScreen = document.createElement("success-screen");
+      document.body.appendChild(successScreen);
 
-    // Remove success screen after some time
-    setTimeout(() => {
-      document.body.removeChild(successScreen);
-    }, 1400);
+      // Remove success screen after some time
+      setTimeout(() => {
+        document.body.removeChild(successScreen);
+      }, 1400);
+
+    } catch(err){
+      window.alert(`The file name "${evt.detail.name}" 
+        is either taken or not allowed. Please try again.`);
+    }
   });
 });
 

--- a/source/client/assets/scripts/FolderAList/FolderAUpload.js
+++ b/source/client/assets/scripts/FolderAList/FolderAUpload.js
@@ -43,21 +43,27 @@ addButton.addEventListener("click", () => {
 
   // When the user submits a new audio file
   createFolderAObject.addEventListener("fileSubmitted", evt => {
-    // Remove the input prompt
-    document.body.removeChild(createFolderAObject);
+    try{
+      // Create a new audio card
+      folder_utils.add_typeA(evt.detail.parent,evt.detail.name);
+      createFolderA(evt.detail.name);
 
-    // Create a new audio card
-    createFolderA(evt.detail.name);
-    folder_utils.add_typeA(evt.detail.parent,evt.detail.name);
+      // Remove the input prompt
+      document.body.removeChild(createFolderAObject);
 
-    // Show success screen
-    const successScreen = document.createElement("success-screen");
-    document.body.appendChild(successScreen);
+      // Show success screen
+      const successScreen = document.createElement("success-screen");
+      document.body.appendChild(successScreen);
 
-    // Remove success screen after some time
-    setTimeout(() => {
-      document.body.removeChild(successScreen);
-    }, 1400);
+      // Remove success screen after some time
+      setTimeout(() => {
+        document.body.removeChild(successScreen);
+      }, 1400);
+
+    } catch(err){
+      window.alert(`The folder name "${evt.detail.name}" 
+        is either taken or not allowed. Please try again.`);
+    }
   });
 });
 

--- a/source/client/assets/scripts/FolderFList/FolderFUpload.js
+++ b/source/client/assets/scripts/FolderFList/FolderFUpload.js
@@ -42,21 +42,27 @@ addButton.addEventListener("click", () => {
 
   // When the user submits a new audio file
   createFileFObject.addEventListener("fileSubmitted", evt => {
-    // Remove the input prompt
-    document.body.removeChild(createFileFObject);
+    try{
+      // Create a new audio card
+      folder_utils.add_typeF(evt.detail.name);
+      createFolderF(evt.detail.name);
 
-    // Create a new audio card
-    createFolderF(evt.detail.name);
-    folder_utils.add_typeF(evt.detail.name);
+      // Remove the input prompt
+      document.body.removeChild(createFileFObject);
 
-    // Show success screen
-    const successScreen = document.createElement("success-screen");
-    document.body.appendChild(successScreen);
+      // Show success screen
+      const successScreen = document.createElement("success-screen");
+      document.body.appendChild(successScreen);
 
-    // Remove success screen after some time
-    setTimeout(() => {
-      document.body.removeChild(successScreen);
-    }, 1400);
+      // Remove success screen after some time
+      setTimeout(() => {
+        document.body.removeChild(successScreen);
+      }, 1400);
+
+    } catch (err){
+      window.alert(`The folder name "${evt.detail.name}"
+        is either taken or not allowed. Please try again.`);
+    }
   });
 });
 


### PR DESCRIPTION
Previously the frontend code did not take advantage of the errors the backend code threw and this allowed users to create files/folders that had duplicate names or no name.

Now for each page (TypeF, TypeA, and AudioObject) if a user attempts to create a new folder/file that already exists or with no name, they will be prompted to try again.