### PR TITLE
Implemented fix for note container bug

### DIFF
--- a/source/client/assets/styles/audio-object.css
+++ b/source/client/assets/styles/audio-object.css
@@ -93,6 +93,7 @@
   padding: 7px 10px;
   background-color: var(--secondary-color);
   animation: fadeIn 0.75s;
+  word-wrap: break-word;
 }
 
 .timestamp {


### PR DESCRIPTION
#71 - Issue fixed
 
Fixed the bug where long notes would go outside its container and not break into a new line. When the note is long, the notes now stay in the container and break onto a new line.