### PR TITLE
Complete the type-a.test.js

### DIFF
--- a/testing/type-a.test.js
+++ b/testing/type-a.test.js
@@ -121,12 +121,36 @@ test("Test add_audio: invalid address - NO PATH", () => {
   expect(getter).toThrow("Invalid audio file path");
 });
 
-// //Test get_audio(audioObjName)
-// test("Test get_audio: correct return - CORRECT NAME", () => {
-//     const newTypeA = new functions.TypeA("test_typeA");
-//     newTypeA.add_audio("test", TESTFILE_REL);
+/**
+ * Test Case: Testing trying to get the audioObj with the correct name
+ * 
+ * Input: name of the audioObj
+ * Output: We are checking for a pass because we should have the correct 
+ * audioObj returned with the corresponding name of the audioObj
+ */ 
+test("Test get_audio: correct return - CORRECT NAME", () => {
+  const newTypeA = new functions.TypeA("test_typeA");
+  newTypeA.add_audio("test", TESTFILE_REL);
+  const testAudioObj = newTypeA.get_audio("test");
+  console.log(testAudioObj);
 
-// });
+  expect(testAudioObj).toEqual({ "path": TESTFILE_REL, "notes": {} });
+});
+
+/**
+ * Test Case: Testing trying to get the audioObj with a non-exisiting name
+ * 
+ * Input: a name that doesn't exist in 
+ * Output: We are checking for a pass because we should have the correct 
+ * audioObj returned with the corresponding name of the audioObj
+ */ 
+ test("Test get_audio: correct return - CORRECT NAME", () => {
+  const newTypeA = new functions.TypeA("test_typeA");
+  newTypeA.add_audio("test", TESTFILE_REL);
+  const testAudioObj = newTypeA.get_audio("test");
+  console.log(testAudioObj);
+  expect(testAudioObj).toEqual({ "path": TESTFILE_REL, "notes": {} });
+});
 
 // //Test get_all_audio_names()
 // test("Test get_all_audio: correct return - CORRECT USAGE", () => {
@@ -382,3 +406,19 @@ test("Testing clear_folder: absolute path", () => {
   newTypeA.clear_folder();
   expect(newTypeA).toEqual({ "dict_audio": {} });
 });
+
+/**
+ * Test Case: Testing adding audioObj with empty name input
+ * 
+ * Input: audioObj and an empty name 
+ * Output: We checking for an error because we shouldn't be able to add any  
+ * audioObj with no name inputted.
+ */
+
+/**
+ * Test Case: Testing adding audioObj with existed audioObj name
+ * 
+ * Input: none
+ * Output: We checking for a pass because we should be able to delete all the 
+ * audio files within a Type A folder
+ */

--- a/testing/type-a.test.js
+++ b/testing/type-a.test.js
@@ -26,7 +26,7 @@ const TESTFILE_ABS = TESTING_ABS_PATH + MP3;
  * Test Case: Testing the constructor of creating type A 
  * 
  * Input: A name for type A folder
- * Output: We checking for true because we just created a new folder 
+ * Output: We check for true because we just created a new folder 
  * with no audios in it
  */
 test("Test constructor typeA:", () => {
@@ -38,7 +38,7 @@ test("Test constructor typeA:", () => {
  * Test Case: Testing adding invalid name of audio file to a type A folder
  * 
  * Input: empty string to represent name of audio file relative path
- * Output: We checking for error because we can not add a empty name for 
+ * Output: We check for error because we can not add a empty name for 
  * a audio file 
  */ 
 test("Test add_audio: invalid name relative path - EMPTY STRING", () => {
@@ -54,7 +54,7 @@ test("Test add_audio: invalid name relative path - EMPTY STRING", () => {
  * Test Case: Testing adding invalid name of audio file to a type A folder
  * 
  * Input: empty string to represent name of audio file absolute path
- * Output: We checking for error because we can not add a empty name for 
+ * Output: We check for error because we can not add a empty name for 
  * a audio file 
  */ 
 test("Test add_audio: invalid name absolute path - EMPTY STRING", () => {
@@ -70,7 +70,7 @@ test("Test add_audio: invalid name absolute path - EMPTY STRING", () => {
  * Test Case: Testing adding existing name of audio file to a type A folder
  * 
  * Input: an already existing name of audio file relative path
- * Output: We checking for error because we can not same named audio files in
+ * Output: We check for error because we can not same named audio files in
  * the same type A folder
  */ 
 test("Test add_audio: invalid name relative path - REPEAT STRING", () => {
@@ -89,7 +89,7 @@ test("Test add_audio: invalid name relative path - REPEAT STRING", () => {
  * Test Case: Testing adding existing name of audio file to a type A folder
  * 
  * Input: an already existing name of audio file absolute path
- * Output: We checking for error because we can not same named audio files in
+ * Output: We check for error because we can not same named audio files in
  * the same type A folder
  */ 
 test("Test add_audio: invalid name absolute path - REPEAT STRING", () => {
@@ -109,7 +109,7 @@ test("Test add_audio: invalid name absolute path - REPEAT STRING", () => {
  * folder
  * 
  * Input: a invalid path to a supposed "audio file"
- * Output: We checking for error because we should have an error showing that 
+ * Output: We check for error because we should have an error showing that 
  * that path is invalid and can not be used to create a audio file
  */ 
 test("Test add_audio: invalid address - NO PATH", () => {
@@ -125,7 +125,7 @@ test("Test add_audio: invalid address - NO PATH", () => {
  * Test Case: Testing trying to get the audioObj with the correct name
  * 
  * Input: name of the audioObj
- * Output: We are checking for a pass because we should have the correct 
+ * Output: We check for a pass because we should have the correct 
  * audioObj returned with the corresponding name of the audioObj
  */ 
 test("Test get_audio: correct return - CORRECT NAME", () => {
@@ -138,30 +138,82 @@ test("Test get_audio: correct return - CORRECT NAME", () => {
 });
 
 /**
- * Test Case: Testing trying to get the audioObj with a non-exisiting name
+ * Test Case: Testing trying to get an audioObj with a non-exisiting audioObj
+ * name
  * 
- * Input: a name that doesn't exist in 
- * Output: We are checking for a pass because we should have the correct 
- * audioObj returned with the corresponding name of the audioObj
+ * Input: an AudioObj name that doesn't exist
+ * Output: We are checking for an error because we should not have any 
+ * audioObj returned with this non-exisiting name
  */ 
- test("Test get_audio: correct return - CORRECT NAME", () => {
+// test("Test get_audio: correct return - CORRECT NAME", () => {
+//  const newTypeA = new functions.TypeA("test_typeA");
+//  newTypeA.add_audio("test", TESTFILE_REL);
+//  const testAudioObj = newTypeA.get_audio("test1");
+//  console.log(testAudioObj);
+//  expect(testAudioObj).toEqual({});
+//});
+
+/**
+ * Test Case: Testing trying to get all audioObjs' names 
+ * Input: None
+ * Output: We check for a pass because we should have all the audioObjs'
+ * name returned from the typeA folder
+ */ 
+test("Test get_all_audio: correct return - CORRECT USAGE", () => {
   const newTypeA = new functions.TypeA("test_typeA");
-  newTypeA.add_audio("test", TESTFILE_REL);
-  const testAudioObj = newTypeA.get_audio("test");
-  console.log(testAudioObj);
-  expect(testAudioObj).toEqual({ "path": TESTFILE_REL, "notes": {} });
+  for(let i = 0; i < 20; i++){
+    newTypeA.add_audio(`test ${i}`, TESTFILE_REL);
+  }
+  const names = newTypeA.get_all_audio_names();
+
+  expect(names).toEqual([
+    'test 0',  'test 1',  'test 2',
+    'test 3',  'test 4',  'test 5',
+    'test 6',  'test 7',  'test 8',
+    'test 9',  'test 10', 'test 11',
+    'test 12', 'test 13', 'test 14',
+    'test 15', 'test 16', 'test 17',
+    'test 18', 'test 19'
+  ]);
 });
 
-// //Test get_all_audio_names()
-// test("Test get_all_audio: correct return - CORRECT USAGE", () => {
+/**
+ * Test Case: Testing trying to get all audioObjs' names 
+ * Input: None
+ * Output: We check for a pass because we should have all the audioObjs'
+ * name returned from the typeA folder
+ */ 
+test("Test get_all_audio: correct empty return - CORRECT USAGE", () => {
+  const newTypeA = new functions.TypeA("test_typeA");
+  const names = newTypeA.get_all_audio_names();
 
-// });
+  expect(names).toEqual([]);
+});
+
+
+/**
+ * Test Case: Testing trying to update audio file name with correct name
+ * 
+ * Input: old name of relative path audio file and a new name that has never 
+ * been used
+ * Output: We check for a pass because we should be able to update an audioObj's
+ * name with a new name that's not empty and has not been used before.
+ */ 
+test("Test update_audio_name: correct update - CORRECT USAGE", () => {
+  const newTypeA = new functions.TypeA("test_typeA"); 
+  newTypeA.add_audio("test", TESTFILE_REL);
+  newTypeA.update_audio_name("test", "newTest");
+
+  expect(newTypeA.get_audio("newTest")).toEqual({ 
+    "path": TESTFILE_REL, "notes": {} 
+  });
+});
 
 /**
  * Test Case: Testing trying to update audio file name with empty name
  * 
  * Input: old name of relative path audio file and empty string as new name
- * Output: We checking for error because we can not an empty string as audio 
+ * Output: We check for error because we can not an empty string as audio 
  * file name
  */ 
 test("Test update_audio_name: empty newName relative path - EMPTY STRING", () => {
@@ -178,8 +230,8 @@ test("Test update_audio_name: empty newName relative path - EMPTY STRING", () =>
  * Test Case: Testing trying to update audio file name with empty name
  * 
  * Input: old name of absolute path audio file and empty string as new name
- * Output: We checking for error because we can not have a empty string as audio 
- * file name
+ * Output: We check for error because we can not have a empty string as 
+ * audio file name
  */ 
 test("Test update_audio_name: empty newName absolute path - EMPTY STRING", () => {
   function getter() {
@@ -195,8 +247,8 @@ test("Test update_audio_name: empty newName absolute path - EMPTY STRING", () =>
  * Test Case: Testing trying to update empty audio file name with new name 
  * 
  * Input: old name being empty string and new name of relative path audio file
- * Output: We checking for error because we can not have a empty string as audio 
- * file name
+ * Output: We check for error because we can not have a empty string as
+ * audio file name
  */ 
 test("Test update_audio_name: empty oldName relative path - EMPTY STRING", () => {
   function getter() {
@@ -212,7 +264,7 @@ test("Test update_audio_name: empty oldName relative path - EMPTY STRING", () =>
  * Test Case: Testing trying to update empty audio file name with new name
  * 
  * Input: old name being empty string and new name of absolute path audio file
- * Output: We checking for error because we can not an empty string as audio 
+ * Output: We check for error because we can not an empty string as audio 
  * file name
  */ 
 test("Test update_audio_name: empty oldName absolute path - EMPTY STRING", () => {
@@ -229,7 +281,7 @@ test("Test update_audio_name: empty oldName absolute path - EMPTY STRING", () =>
  * Test Case: Testing the updating a non existing audio file
  * 
  * Input: a audio file that does not exist
- * Output: We checking for error because we can not find a audio file
+ * Output: We check for error because we can not find a audio file
  * that exist with the name that came in as a input
  */
 test("Test update_audio_name: invalid name - DOES NOT EXIST", () => {
@@ -248,7 +300,7 @@ test("Test update_audio_name: invalid name - DOES NOT EXIST", () => {
  * 
  * Input: old name that it audio file which was a relative path and new
  * repeat name we are trying to use
- * Output: We checking for error because we can not have two audio files that
+ * Output: We check for error because we can not have two audio files that
  * are of the same name
  */
 test("Test update_audio_name: Audio same name relative path - REPEATED NAME FILE", () => {
@@ -270,7 +322,7 @@ test("Test update_audio_name: Audio same name relative path - REPEATED NAME FILE
  * 
  * Input: old name that it audio file which was a absolute path and new
  * repeat name we are trying to use
- * Output: We checking for error because we can not have two audio files that
+ * Output: We check for error because we can not have two audio files that
  * are of the same name
  */
 test("Test update_audio_name: Audio same name absolute path - REPEATED NAME FILE", () => {
@@ -291,7 +343,7 @@ test("Test update_audio_name: Audio same name absolute path - REPEATED NAME FILE
  * Test Case: Testing deleting audio file from type A folder
  * 
  * Input: audio file name and relative path audio file
- * Output: We checking for pass because we should be able to delete an existing
+ * Output: We check for pass because we should be able to delete an existing
  * audio file in our program
  */
 //Test delete_audio(audioName)
@@ -323,7 +375,7 @@ test("Test delete_audio: correct delete relative path - CORRECT STORAGE", () => 
  * Test Case: Testing deleting a non existing audio file in type A folder
  * 
  * Input: Non existing name of audio file
- * Output: We checking for an error because we should not be able to delete 
+ * Output: We check for an error because we should not be able to delete 
  * a audio file that does not exist
  */
 test("Test delete_audio: invalid name relative path - DOES NOT EXIST", () => {
@@ -345,7 +397,7 @@ test("Test delete_audio: invalid name relative path - DOES NOT EXIST", () => {
  * Test Case: Testing deleting a non existing audio file in type A folder
  * 
  * Input: Non existing name of audio file
- * Output: We checking for an error because we should not be able to delete 
+ * Output: We check for an error because we should not be able to delete 
  * a audio file that does not exist
  */
 test("Test delete_audio: invalid name absolute path- DOES NOT EXIST", () => {
@@ -367,7 +419,7 @@ test("Test delete_audio: invalid name absolute path- DOES NOT EXIST", () => {
  *  Test Case: Testing clearing a type A folder which used relative path audios
  * 
  * Input: none
- * Output: We checking for a pass because we should be able to delete all the 
+ * Output: We check for a pass because we should be able to delete all the 
  * audio files within a Type A folder
  */
 test("Testing clear_folder: relative path", () => {
@@ -389,7 +441,7 @@ test("Testing clear_folder: relative path", () => {
  * Test Case: Testing clearing a type A folder which used absolute path audios
  * 
  * Input: none
- * Output: We checking for a pass because we should be able to delete all the 
+ * Output: We check for a pass because we should be able to delete all the 
  * audio files within a Type A folder
  */
 test("Testing clear_folder: absolute path", () => {
@@ -406,19 +458,3 @@ test("Testing clear_folder: absolute path", () => {
   newTypeA.clear_folder();
   expect(newTypeA).toEqual({ "dict_audio": {} });
 });
-
-/**
- * Test Case: Testing adding audioObj with empty name input
- * 
- * Input: audioObj and an empty name 
- * Output: We checking for an error because we shouldn't be able to add any  
- * audioObj with no name inputted.
- */
-
-/**
- * Test Case: Testing adding audioObj with existed audioObj name
- * 
- * Input: none
- * Output: We checking for a pass because we should be able to delete all the 
- * audio files within a Type A folder
- */


### PR DESCRIPTION
For the get_audio function, there're more tests to add since the original backend code is missing the error handling for the incorrect/non-existent audioObjName. But I can't add the backend code until the code format is fixed. I'll wait for Alex to finish that first. 